### PR TITLE
fix(#13): fix GitHub issue/comment scraping for stale repos

### DIFF
--- a/plugins/github.js
+++ b/plugins/github.js
@@ -5000,12 +5000,6 @@ async function getRepositories({
     )) {
       logger.info(`Found ${response.data.length} repositories`);
       for (const repo of response.data) {
-        if (since && repo.updated_at && new Date(repo.updated_at) < new Date(since)) {
-          logger.debug(
-            `Skipping repository ${repo.name} as it is older than ${since}`
-          );
-          return repos;
-        }
         if (!repo.updated_at) {
           logger.warn(`Repository ${repo.name} has no updated_at`);
           continue;
@@ -5185,7 +5179,7 @@ async function getIssues({
     const query = `
       query($owner: String!, $repo: String!, $cursor: String) {
         repository(owner: $owner, name: $repo) {
-          issues(first: 50, orderBy: { field: UPDATED_AT, direction: DESC }, after: $cursor) {
+          issues(first: 50, states: [OPEN, CLOSED], orderBy: { field: UPDATED_AT, direction: DESC }, after: $cursor) {
             pageInfo {
               hasNextPage
               endCursor
@@ -5445,6 +5439,17 @@ function activitiesFromComments(comments, repo) {
   }
   return activities;
 }
+function resolveScrapeDays(config, logger) {
+  const rawValue = config.scrapeDays ?? process.env.SCRAPE_DAYS ?? 7;
+  const scrapeDays = Number(rawValue);
+  if (!Number.isFinite(scrapeDays) || scrapeDays < 0) {
+    logger.warn(
+      `Invalid SCRAPE_DAYS value "${rawValue}", defaulting to 7 days`
+    );
+    return 7;
+  }
+  return scrapeDays;
+}
 function activitiesFromPullRequests(pullRequests, repo) {
   const activities = [];
   for (const pullRequest of pullRequests) {
@@ -5548,7 +5553,7 @@ async function persistRepoActivities(db, activities, logger, defaultRole) {
   return saved;
 }
 async function getActivities({ db, config, logger }) {
-  const scrapeDays = 7;
+  const scrapeDays = resolveScrapeDays(config, logger);
   const pool2 = getOctokitPool(config, logger);
   const org = config.githubOrg;
   const dataDir2 = config.dataDir || void 0;


### PR DESCRIPTION
## Summary

Fixes partial GitHub activity ingestion for repositories that had stale `repository.updated_at` timestamps, which could cause valid recent issue/comment activity to be skipped.

## Changes

- Removed the early skip gate based on `repo.updated_at < since`
- Updated GitHub issue fetching to include both `OPEN` and `CLOSED` states
- Made scrape lookback window configurable via `config.scrapeDays` or `SCRAPE_DAYS`
- Added issue `#13` handoff notes, including verification and backfill guidance

## Context

Resolves #13, where recent `issue_opened` and `commented` activities from `ohcnetwork/design` were missing while other activity types (e.g. `pr_opened`) continued to update.

## Verification

- Ran `node --check plugins/github.js`
- Verified reported missing events using `gh` API:
  - `ohcnetwork/design#92` (issue opened)
  - recent comment activity on `ohcnetwork/design#85`

## Follow-up

Run a manual scrape with a wider lookback window (for example, `days: 30`) to backfill already-missed April 2026 events.